### PR TITLE
fix: Dont pass parent configurable fields to subgraphs

### DIFF
--- a/oap_supervisor/agent.py
+++ b/oap_supervisor/agent.py
@@ -90,13 +90,27 @@ def make_child_graphs(cfg: GraphConfigPydantic, access_token: Optional[str] = No
             headers=headers,
         )
 
-        async def remote_graph_wrapper(state):
-            # Ensure we overwrite the thread ID so that sub-agents do NOT inherit
-            # the thread ID, and thus the config from the parent/previous run.
-            thread_id = str(uuid.uuid4())
-            return await remote_graph.ainvoke(
-                state, {"configurable": {"thread_id": thread_id}}
-            )
+        async def remote_graph_wrapper(state, config: RunnableConfig):
+            # Filter out keys that are already defined in GraphConfigPydantic
+            # to avoid the child graph inheriting config from the supervisor
+            # (e.g. system_prompt)
+            graph_config_fields = set(GraphConfigPydantic.model_fields.keys())
+            
+            if "configurable" in config:
+                config = dict(config)
+                config["configurable"] = {
+                    k: v for k, v in config["configurable"].items()
+                    if k not in graph_config_fields
+                }
+
+            if "metadata" in config:
+                config = dict(config)
+                config["metadata"] = {
+                    k: v for k, v in config["metadata"].items()
+                    if k not in graph_config_fields
+                }
+            
+            return await remote_graph.ainvoke(state, config)
 
         workflow = (
             StateGraph(AgentState)

--- a/oap_supervisor/agent.py
+++ b/oap_supervisor/agent.py
@@ -3,7 +3,6 @@ from langgraph.pregel.remote import RemoteGraph
 from langchain_openai import ChatOpenAI
 from langgraph_supervisor import create_supervisor
 from pydantic import BaseModel, Field
-import uuid
 from typing import List, Optional
 from langchain_core.runnables import RunnableConfig
 from langgraph.prebuilt.chat_agent_executor import AgentState
@@ -95,21 +94,23 @@ def make_child_graphs(cfg: GraphConfigPydantic, access_token: Optional[str] = No
             # to avoid the child graph inheriting config from the supervisor
             # (e.g. system_prompt)
             graph_config_fields = set(GraphConfigPydantic.model_fields.keys())
-            
+
             if "configurable" in config:
                 config = dict(config)
                 config["configurable"] = {
-                    k: v for k, v in config["configurable"].items()
+                    k: v
+                    for k, v in config["configurable"].items()
                     if k not in graph_config_fields
                 }
 
             if "metadata" in config:
                 config = dict(config)
                 config["metadata"] = {
-                    k: v for k, v in config["metadata"].items()
+                    k: v
+                    for k, v in config["metadata"].items()
                     if k not in graph_config_fields
                 }
-            
+
             return await remote_graph.ainvoke(state, config)
 
         workflow = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pydantic==2.11.3",
     "supabase>=2.15.1",
     "aiohttp>=3.8.0",
-    "langgraph-supervisor>=0.0.22",
+    "langgraph-supervisor>=0.0.23",
 ]
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -668,16 +668,16 @@ wheels = [
 
 [[package]]
 name = "langgraph-supervisor"
-version = "0.0.22"
+version = "0.0.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "langgraph-prebuilt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/ea/bd0e5f7df3f9a03552126617014ba8955d26d3a92c6ae082db2b82cc975a/langgraph_supervisor-0.0.22.tar.gz", hash = "sha256:b04def1a13acfcbf1f87594ff74c39bd7e535681ba9150711c8dd846541f53d1", size = 20090 }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/95/9007bfdfea7983260a4718ea5e3a62d73a2e526ae7d86db6b3a855d7ded0/langgraph_supervisor-0.0.23.tar.gz", hash = "sha256:a7f08dbfb6c219281f40a8aa269b184062f02e01949f3ebefe50baaa33f1aa32", size = 20189 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/23/61fd7a8596743f7dccfdddca88fe1f2f759ad463e9ecc0b1c42895e30c2a/langgraph_supervisor-0.0.22-py3-none-any.whl", hash = "sha256:c46ad29129b6f769b1a1dfb57658ab265e34ffbfab38c94a06d73ab2e523faa7", size = 15048 },
+    { url = "https://files.pythonhosted.org/packages/c8/32/6a36105a617081c815be2a8e9c5bd69bc84acfc8c4a74647751acc94abe5/langgraph_supervisor-0.0.23-py3-none-any.whl", hash = "sha256:f2acd17afb175e962d11d44a9678cc11c4a2df6e0c2627503f14d7ef30dea5a9", size = 15164 },
 ]
 
 [[package]]
@@ -770,7 +770,7 @@ requires-dist = [
     { name = "langchain-core", specifier = "==0.3.59" },
     { name = "langchain-openai", specifier = "==0.3.16" },
     { name = "langgraph", specifier = "==0.4.5" },
-    { name = "langgraph-supervisor", specifier = ">=0.0.22" },
+    { name = "langgraph-supervisor", specifier = ">=0.0.23" },
     { name = "pydantic", specifier = "==2.11.3" },
     { name = "supabase", specifier = ">=2.15.1" },
 ]


### PR DESCRIPTION
Removes the hack for thread ID, instead using the new supervisor version where this is fixed. also filters out all configurable fields present in the supervisor's config so that the child does not inherit them. this will instead cause the child to get configurable field from the assistant, which is what we want